### PR TITLE
Add support for TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+types
 
 # Installed npm modules
 node_modules

--- a/doc/supporting-typescript.md
+++ b/doc/supporting-typescript.md
@@ -1,0 +1,8 @@
+# Supporting TypeScript
+
+* Creating `.d.ts` files from `.js` files: https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html
+  * This produces multiple `.d.ts` files.
+  * Single “bundled” `.d.ts` file: use `--outfile`. https://stackoverflow.com/questions/16660277/combine-multiple-typescript-files-into-one-typescript-definition-file
+    * I could not get the setup to work with a single compound `.d.ts` file. That would have made the package exports simpler.
+* Specifying "types" with package exports: https://www.typescriptlang.org/docs/handbook/modules/reference.html#example-explicit-types-condition
+* Overloading function signatures in JSDoc: https://austingil.com/typescript-function-overloads-with-jsdoc/

--- a/package.json
+++ b/package.json
@@ -5,16 +5,23 @@
   "author": "Steven Levithan",
   "license": "MIT",
   "type": "module",
-  "exports": "./src/index.js",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./src/index.js"
+    }
+  },
   "scripts": {
     "build": "esbuild src/index.js --bundle --minify --outfile=dist/regex.min.js --global-name=Regex",
+    "types": "npx --package=typescript tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outdir types",
     "pretest": "npm run build",
     "test": "jasmine",
     "prepublish": "npm test"
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "types"
   ],
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -28,9 +28,11 @@ Can be called in multiple ways:
 4. `` regex.bind(RegExpSubclass)`…` `` - With a `this` that specifies a different constructor.
 
 @type {{
-  (flags?: string) => (TemplateStringsArray, ...values) => RegExp;
-  (options: RegexTagOptions) => (TemplateStringsArray, ...values) => RegExp;
-  (template: TemplateStringsArray, ...values) => RegExp;
+  (templateStrings: TemplateStringsArray, ...substitutions: Array<string | RegExp | PartialPattern>) => RegExp,
+
+  (flags?: string) => (templateStrings: TemplateStringsArray, ...substitutions: Array<string | RegExp | PartialPattern>) => RegExp,
+
+  (options: RegexTagOptions) => (templateStrings: TemplateStringsArray, ...substitutions: Array<string | RegExp | PartialPattern>) => RegExp,
 }}
 */
 const regex = function(first, ...values) {
@@ -51,7 +53,7 @@ const regex = function(first, ...values) {
 
 /**
 Makes a UnicodeSets-mode RegExp from a template and values to fill the template holes.
-@param {RegExpConstructor | (pattern: string, flags: string) => RegExp} constructor
+@param {new (pattern: string, flags: string) => RegExp} constructor
 @param {RegexTagOptions} options
 @param {TemplateStringsArray} template
 @param {...any} values


### PR DESCRIPTION
Someone who knows more about .d.ts files and packages should probably take a look at what I have set up. I’ll ask on Mastodon.

* I tested the setup locally via a TypeScript repo and `npm add ../regex` and the types worked.
* `dist/regex.min.js` should maybe be included in the package exports in some way.
* You may want to clear `dist/` before "build" and `types/` before "types". I’m using package `shx` for cross-platform shell commands.
* Maybe:
  * Rename "build" to "esbuild"
  * Define "build" as "npm run esbuild && npm run types"
* I don’t know whether or not "typescript" should become a devDependency.
* `@overload` is another option for overloading `regex` but I’m not sure in which of the multiple JSDoc comments the actual documentation would go.
  * Benefit of `@overload`: It may help with specifying `this` for `regex`. I don’t know how to best do that. I avoid using `this` as an implicit parameter in my code.

Command for checking if the types are correct (potential addition to `package.json` "scripts"):

```
npx --package=@arethetypeswrong/cli attw .
```