### PR TITLE
CommonJS bundle and sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,18 @@
   "exports": {
     ".": {
       "types": "./types/regex.d.ts",
-      "import": "./dist/regex.mjs"
+      "import": "./dist/regex.mjs",
+      "require": "./dist/regex.cjs"
     }
   },
   "browser": "./dist/regex.min.js",
   "scripts": {
-    "bundle:global": "esbuild src/regex.js --global-name=Regex --bundle --minify --outfile=dist/regex.min.js",
-    "bundle:esm": "esbuild src/regex.js --format=esm --bundle --outfile=dist/regex.mjs",
+    "bundle:global": "esbuild --sourcemap src/regex.js --global-name=Regex --bundle --minify --outfile=dist/regex.min.js",
+    "bundle:esm": "esbuild --sourcemap src/regex.js --format=esm --bundle --outfile=dist/regex.mjs",
+    "bundle:cjs": "esbuild --sourcemap src/regex.js --format=cjs --bundle --outfile=dist/regex.cjs",
     "types": "tsc src/regex.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outdir types",
     "prebuild": "rm -rf dist/* types/*",
-    "build": "npm run bundle:global && npm run bundle:esm && npm run types",
+    "build": "npm run bundle:global && npm run bundle:esm && npm run bundle:cjs && npm run types",
     "pretest": "npm run build",
     "test": "jasmine && tsc --project spec/types/tsconfig.test.json",
     "prepare": "npm test"


### PR DESCRIPTION
updates the build script to include a CommonJS bundle and sourcemaps.

Previously, only the global and ESM bundles were included. Now, the CommonJS bundle is also generated during the build process. This ensures that the library can be used in CommonJS environments. 

Additionally, sourcemaps are now generated for all bundles, making it easier to debug and trace issues in the code.