### PR TITLE
pattern TypeScript changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     }
   },
   "browser": "./dist/regex.min.js",
+  "types": "./types/regex.d.ts",
   "scripts": {
     "bundle:global": "esbuild src/regex.js --global-name=Regex --bundle --minify --sourcemap --outfile=dist/regex.min.js",
     "bundle:esm": "esbuild src/regex.js --format=esm --bundle --sourcemap --outfile=dist/regex.mjs",

--- a/src/pattern.js
+++ b/src/pattern.js
@@ -11,6 +11,9 @@ export class Pattern {
 }
 
 /**
+@typedef {string | RegExp | Pattern | number} InterpolatedValue
+*/
+/**
 Returns a value that can be interpolated into a `regex` template string without having its special
 characters escaped.
 
@@ -24,7 +27,7 @@ Can be called as a function or template tag:
 
 @overload
 @param {TemplateStringsArray} template
-@param {...string} substitutions
+@param {...InterpolatedValue} substitutions
 @returns {Pattern}
 */
 export function pattern(first, ...substitutions) {


### PR DESCRIPTION
This package is amazing, thank you!

I am using it with TypeScript and have some improvements:
- Add top-level "types" field to package.json. Some tools may only use the "types" field instead of "exports". For example, I was simply using `tsc` to check types and it couldn't resolve the package without the field. **edit: Separated this change to https://github.com/slevithan/regex/pull/23 since the conversation in this PR is focused on pattern usage.**
- Fix `pattern` substitutions type to match `regex`. I was trying to use patterns nested in other patterns, but currently the `pattern` `substitutions` type only allows strings. I updated it to match the `InterpolatedValue` in `regex`.