### PR TITLE
Add top-level types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     }
   },
   "browser": "./dist/regex.min.js",
+  "types": "./types/regex.d.ts",
   "scripts": {
     "bundle:global": "esbuild src/regex.js --global-name=Regex --bundle --minify --sourcemap --outfile=dist/regex.min.js",
     "bundle:esm": "esbuild src/regex.js --format=esm --bundle --sourcemap --outfile=dist/regex.mjs",


### PR DESCRIPTION
Some tools (e.g. tsc) use the top-level types field only. Here is their guide to publishing types with npm packages: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

For example, I was checking types with `tsc` 4.7.4 on my project that depends on regex. Here's the errors I get:

```
$ tsc --noEmit
src/redacted:21:23 - error TS2307: Cannot find module 'regex' or its corresponding type declarations.
21 import { regex } from "regex";
                         ~~~~~~~
src/redacted.ts:5:32 - error TS2307: Cannot find module 'regex' or its corresponding type declarations.
5 import { pattern, regex } from "regex";
                                 ~~~~~~~
src/redacted.ts:1:32 module 'regex' or its corresponding type declarations.
1 import { pattern, regex } from "regex";
                                 ~~~~~~~
```

This change fixed it for me.