### PR TITLE
fix: Convert numbers to hexadecimal inside Unicode escape sequences

### DIFF
--- a/spec/interpolate-number.spec.js
+++ b/spec/interpolate-number.spec.js
@@ -1,0 +1,13 @@
+describe('interpolation: numbers', () => {
+  describe('in default context', () => {
+    it('should convert numbers to hexadecimal in enclosed tokens', () => {
+      expect('a').toMatch(regex`\u{${97}}`);
+    });
+  });
+
+  describe('in character class context', () => {
+    it('should convert numbers to hexadecimal in enclosed tokens', () => {
+      expect('a').toMatch(regex`[\u{${97}}]`);
+    });
+  });
+});

--- a/src/regex.js
+++ b/src/regex.js
@@ -263,6 +263,13 @@ function interpolate(value, flags, regexContext, charClassContext, wrapEscapedSt
     // break sandboxing) since other errors would be handled by the invalid generated regex syntax
     throw new Error('Interpolation preceded by invalid incomplete token');
   }
+  if (
+    typeof value === "number" &&
+    (regexContext === RegexContext.ENCLOSED_TOKEN || charClassContext === CharClassContext.ENCLOSED_TOKEN)
+  ) {
+    // No need to care about the token type since `\p{number}` and `\P{number}` would result in an error anyway
+    return value.toString(16);
+  }
   const isPattern = value instanceof Pattern;
   let escapedValue = '';
   if (!(value instanceof RegExp)) {


### PR DESCRIPTION
Feel free to suggest a better comment that you feel comfortable with.

For simplicity, this PR doesn’t distinguish between Unicode and Unicode property escape sequences. It works by the fact that, among the currently allowed `LoneUnicodePropertyNameOrValue`, only `gc`, `sc` and `scx` start with a lowercase character and none of them are purely `a`~`f`. Don’t hesitate to close this PR if you would like to achieve this by separating `ENCLOSED_TOKEN` to `P_TOKEN` and `U_TOKEN` instead.

Only minimal test cases are written, I’d love it if you could take over and include more.