### PR TITLE
Adds CommonJS to regex/internals

### DIFF
--- a/internals.d.ts
+++ b/internals.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/cjs/internals.js';

--- a/internals.js
+++ b/internals.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/internals');

--- a/package.json
+++ b/package.json
@@ -17,8 +17,14 @@
       }
     },
     "./internals": {
-      "types": "./dist/esm/internals.d.ts",
-      "import": "./src/internals.js"
+      "import": {
+        "types": "./dist/esm/internals.d.ts",
+        "default": "./dist/esm/internals.js"
+      },
+      "require": {
+        "types": "./dist/cjs/internals.d.ts",
+        "default": "./dist/cjs/internals.js"
+      }
     }
   },
   "browser": "./dist/regex.min.js",
@@ -27,18 +33,22 @@
   "scripts": {
     "bundle:global": "esbuild src/regex.js --global-name=Regex --bundle --minify --sourcemap --outfile=dist/regex.min.js",
     "bundle:esm": "esbuild src/regex.js --format=esm --bundle --sourcemap --outfile=dist/esm/regex.js",
+    "bundle:esm:internals": "esbuild src/regex.js --format=esm --bundle --sourcemap --outfile=dist/esm/internals.js",
     "bundle:cjs": "esbuild src/regex.js --format=cjs --bundle --sourcemap --outfile=dist/cjs/regex.js",
+    "bundle:cjs:internals": "esbuild src/internals.js --format=cjs --bundle --sourcemap --outfile=dist/cjs/internals.js",
     "types": "tsc src/regex.js src/internals.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types",
     "prebuild": "rm -rf dist/* types/*",
-    "build": "pnpm run bundle:global && pnpm run bundle:esm && pnpm run bundle:cjs && pnpm run types",
+    "build": "pnpm run bundle:global && pnpm run bundle:esm && pnpm run bundle:cjs && pnpm run bundle:esm:internals && pnpm run bundle:cjs:internals && pnpm run types",
     "postbuild": "node scripts/postbuild.js",
     "pretest": "pnpm run build",
-    "test": "jasmine && tsc --project spec/types/tsconfig.test.json && attw --pack . --entrypoints .",
+    "test": "jasmine && tsc --project spec/types/tsconfig.test.json && attw --pack . --entrypoints . internals",
     "prepublishOnly": "pnpm test"
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "internals.d.ts",
+    "internals.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
> Related to #29.

This is adding CJS/ESM to export `regex/internals`. `attw` looks good to me.

![image](https://github.com/user-attachments/assets/a20dfeb2-38c1-43f7-b00e-1a0cb2f217ff)

As `regex` already supports CommonJS. This pull request would improve platform support for using `regex/internals` (and transient dependents) in environments that doesn't fully support ESM. For example, Webpack 4, which is still commanding about 25.8% of Webpack weekly installations based on data from latest v4 vs. v5.

As `regex` is gaining popularity, packages that transiently depends on `regex/internals` may need this little lifts to get onboard the train. One such example is the very popular code syntax highlighter [`shiki`](https://npmjs.com/package/shiki), which has > 2M weekly downloads. It transiently depends on `regex/internals`.

`regex` is building block for great packages. Personally, as the package already support CommonJS, I think it makes sense to improve `regex/internals` support for broader platforms as well, including some popular but slowly deprecating platforms. It would help dependents to improve their build environment supports.

The other way to solve the problem would be embedding all packages down to `regex` via esbuild `noExternal` options. While this is an acceptable solution, it would hurt vulnerability patching process as the code is embedded deeply.

I hope you would consider this pull request.

Notes: barrel files at the root is required for Webpack 4 as it does not understand `package.json/exports`. It could be moved to another directory and copied to the root with the post-build script. I have tested this with a vanilla Webpack 4 + `babel-loader` setup.